### PR TITLE
CI improvements + Python 2.7 Compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,3 +59,10 @@ jobs:
           paths:
             - "/opt/conda/envs/${ENV_NAME}/"
             - "/opt/conda/pkgs"
+      - run:
+          name: Code Coverage
+          command: |
+            source activate ${ENV_NAME}
+
+            echo "[Uploading Coverage]"
+            codecov

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,50 +11,51 @@ jobs:
 
   test-2.7:
     docker:
-      - image: frolvlad/alpine-miniconda3
+      - image: continuumio/miniconda:latest
+    environment:
+      PYTHON: "2.7"
+      ENV_NAME: "dask-mpi-dev"
+
     steps:
-      - run: apk add --no-cache build-base ca-certificates git openssh bash curl
       - checkout
       - restore_cache:
-          keys:
-            - conda-pkgs
-      - run: conda create -q -n dask-mpi-dev python=2.7 && conda env update -f environment-dev.yml --prune
-      - run: source activate dask-mpi-dev && pip install --no-deps -e .
-      - save_cache:
-          key: conda-pkgs
-          paths:
-            - /opt/conda/pkgs
+          key: deps-{{ .Branch }}-2.7-{{ checksum "ci/environment-dev-2.7.yml" }}
+      - run:
+          name: Install and activate conda environment
+          command: ./ci/install-circle.sh
       - run:
           name: Running tests
           command: |
-            source activate dask-mpi-dev
+            source activate ${ENV_NAME}
             pytest --junitxml=test-reports/junit.xml --cov=./ dask_mpi/tests/
-      - run:
-           name: Coverage
-           command: source activate dask-mpi-dev && codecov
-           when: on_success
+      - save_cache:
+          key: deps-{{ .Branch }}-2.7-{{ checksum "ci/environment-dev-2.7.yml" }}
+          paths:
+            - "/opt/conda/envs/${ENV_NAME}/"
+            - "/opt/conda/pkgs"
 
   test-3.6:
     docker:
-      - image: frolvlad/alpine-miniconda3
+      - image: continuumio/miniconda:latest
+
+    environment:
+      PYTHON: "3.6"
+      ENV_NAME: "dask-mpi-dev"
+
     steps:
-      - run: apk add --no-cache build-base ca-certificates git openssh bash curl
       - checkout
       - restore_cache:
-          keys:
-            - conda-pkgs
-      - run: conda create -q -n dask-mpi-dev python=3.6 && conda env update -f environment-dev.yml --prune
-      - run: source activate dask-mpi-dev && pip install --no-deps -e .
-      - save_cache:
-          key: conda-pkgs
-          paths:
-            - /opt/conda/pkgs
+          key: deps-{{ .Branch }}-3.6-{{ checksum "ci/environment-dev-3.6.yml" }}
+      - run:
+          name: Install and activate conda environment
+          command: ./ci/install-circle.sh
       - run:
           name: Running tests
           command: |
-            source activate dask-mpi-dev
+            source activate ${ENV_NAME}
             pytest --junitxml=test-reports/junit.xml --cov=./ dask_mpi/tests/
-      - run:
-           name: Coverage
-           command: source activate dask-mpi-dev && codecov
-           when: on_success
+      - save_cache:
+          key: deps-{{ .Branch }}-3.6-{{ checksum "ci/environment-dev-3.6.yml" }}
+          paths:
+            - "/opt/conda/envs/${ENV_NAME}/"
+            - "/opt/conda/pkgs"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,15 +5,7 @@ workflows:
   default:
     jobs:
       - test-2.7
-          filters:
-            branches:
-              only:
-                - master
       - test-3.6
-          filters:
-            branches:
-              only:
-                - master
 
 jobs:
 

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+omit = 
+    dask_mpi/tests/*.py
+    dask_mpi/_version.py
+    versioneer.py
+    setup.py

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Deploying Dask using MPI4Py
 ===========================
 
-|Gitter|
+|Gitter| |Circle| |Codecov|
 
 Easily deploy Dask Distributed in an existing MPI environment, such as one
 created with the `mpirun` or `mpiexec` MPI launch commands.  See documentation_
@@ -15,6 +15,14 @@ LICENSE
 BSD 3-Clause (See `License File <https://github.com/dask/dask-mpi/blob/master/LICENSE.txt>`__)
 
 .. _documentation:
-.. |Gitter| image:: https://badges.gitter.im/Join%20Chat.svg
+.. |Gitter| image:: https://img.shields.io/gitter/room/dask/dask.svg?style=for-the-badge
    :alt: Join the chat at https://gitter.im/dask/dask
    :target: https://gitter.im/dask/dask?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
+
+
+.. |Circle| image:: https://img.shields.io/circleci/project/github/dask/dask-mpi/master.svg?style=for-the-badge
+    :target: https://circleci.com/gh/dask/dask-mpi/tree/master
+
+.. |Codecov| image:: https://img.shields.io/codecov/c/github/dask/dask-mpi.svg?style=for-the-badge
+    :target: https://codecov.io/gh/dask/dask-mpi
+

--- a/ci/environment-dev-2.7.yml
+++ b/ci/environment-dev-2.7.yml
@@ -1,0 +1,14 @@
+name: dask-mpi-dev
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=2.7
+  - dask
+  - distributed
+  - mpich
+  - mpi4py
+  - versioneer
+  - pytest
+  - coverage
+  - requests

--- a/ci/environment-dev-2.7.yml
+++ b/ci/environment-dev-2.7.yml
@@ -10,5 +10,6 @@ dependencies:
   - mpi4py
   - versioneer
   - pytest
+  - pytest-cov
   - coverage
   - requests

--- a/ci/environment-dev-2.7.yml
+++ b/ci/environment-dev-2.7.yml
@@ -5,7 +5,6 @@ channels:
 dependencies:
   - python=2.7
   - dask
-  - distributed
   - mpich
   - mpi4py
   - versioneer
@@ -13,3 +12,7 @@ dependencies:
   - pytest-cov
   - coverage
   - requests
+  - pip:
+      - git+git://github.com/dask/distributed.git
+
+

--- a/ci/environment-dev-2.7.yml
+++ b/ci/environment-dev-2.7.yml
@@ -12,6 +12,7 @@ dependencies:
   - pytest-cov
   - coverage
   - requests
+  - codecov
   - pip:
       - git+git://github.com/dask/distributed.git
 

--- a/ci/environment-dev-2.7.yml
+++ b/ci/environment-dev-2.7.yml
@@ -13,6 +13,7 @@ dependencies:
   - coverage
   - requests
   - codecov
+  - subprocess32
   - pip:
       - git+git://github.com/dask/distributed.git
 

--- a/ci/environment-dev-3.6.yml
+++ b/ci/environment-dev-3.6.yml
@@ -5,7 +5,6 @@ channels:
 dependencies:
   - python=3.6
   - dask
-  - distributed
   - mpich
   - mpi4py
   - versioneer
@@ -13,3 +12,6 @@ dependencies:
   - pytest-cov
   - coverage
   - requests
+  - pip:
+      - git+git://github.com/dask/distributed.git
+

--- a/ci/environment-dev-3.6.yml
+++ b/ci/environment-dev-3.6.yml
@@ -10,5 +10,6 @@ dependencies:
   - mpi4py
   - versioneer
   - pytest
+  - pytest-cov
   - coverage
   - requests

--- a/ci/environment-dev-3.6.yml
+++ b/ci/environment-dev-3.6.yml
@@ -1,0 +1,14 @@
+name: dask-mpi-dev
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.6
+  - dask
+  - distributed
+  - mpich
+  - mpi4py
+  - versioneer
+  - pytest
+  - coverage
+  - requests

--- a/ci/environment-dev-3.6.yml
+++ b/ci/environment-dev-3.6.yml
@@ -12,6 +12,7 @@ dependencies:
   - pytest-cov
   - coverage
   - requests
+  - codecov
   - pip:
       - git+git://github.com/dask/distributed.git
 

--- a/ci/install-circle.sh
+++ b/ci/install-circle.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+set -eo pipefail
+
+apt-get update; apt-get install -y make
+conda config --set always_yes true --set changeps1 false --set quiet true
+conda update -q conda
+conda config --add channels conda-forge
+conda env create -f ci/environment-dev-${PYTHON}.yml --name=${ENV_NAME} --quiet
+conda env list
+source activate ${ENV_NAME}
+pip install pip --upgrade
+pip install --no-deps --quiet -e .
+conda list -n ${ENV_NAME}

--- a/dask_mpi/cli.py
+++ b/dask_mpi/cli.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, division, absolute_import
 import click
 import dask
 

--- a/dask_mpi/common.py
+++ b/dask_mpi/common.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, division, absolute_import
 from functools import partial
 
 from distributed import Scheduler, Nanny, Worker
@@ -56,7 +57,7 @@ def create_and_run_worker(loop, host=None, rank=0, scheduler_file=None, nanny=Fa
     W = Nanny if nanny else Worker
     worker = W(scheduler_file=scheduler_file,
                loop=loop,
-               name=f'mpi-rank-{rank}',
+               name='mpi-rank-%d' %rank,
                ncores=nthreads,
                local_dir=local_directory,
                services=services,

--- a/dask_mpi/core.py
+++ b/dask_mpi/core.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, division, absolute_import
 import sys
 import dask
 import atexit

--- a/dask_mpi/tests/test_cli.py
+++ b/dask_mpi/tests/test_cli.py
@@ -37,6 +37,8 @@ def test_basic(loop, nanny):
                 assert c.submit(lambda x: x + 1, 10, workers='mpi-rank-1').result() == 11
 
 
+@pytest.mark.skipif(sys.version_info[0] < 3,
+                    reason="Subprocess issues on Python 2")
 def test_no_scheduler(loop):
     with tmpfile(extension='json') as fn:
         with popen(['mpirun', '--np', '2', 'dask-mpi', '--scheduler-file', fn], stdin=subprocess.DEVNULL):

--- a/dask_mpi/tests/test_cli.py
+++ b/dask_mpi/tests/test_cli.py
@@ -19,12 +19,12 @@ from distributed.utils import tmpfile
 from distributed.utils_test import popen
 from distributed.utils_test import loop  # noqa: F401
 
-@pytest.mark.skipif(sys.version_info[0] < 3,
-                    reason="Subprocess issues on Python 2")
+FNULL = open(os.devnull, 'w') # hide output of subprocess
+
 @pytest.mark.parametrize('nanny', ['--nanny', '--no-nanny'])
 def test_basic(loop, nanny):
     with tmpfile(extension='json') as fn:
-        with popen(['mpirun', '--np', '4', 'dask-mpi', '--scheduler-file', fn, nanny], stdin=subprocess.DEVNULL):
+        with popen(['mpirun', '--np', '4', 'dask-mpi', '--scheduler-file', fn, nanny], stdin=FNULL):
             with Client(scheduler_file=fn) as c:
                 start = time()
                 n_workers = len(c.scheduler_info()['workers'])
@@ -37,11 +37,9 @@ def test_basic(loop, nanny):
                 assert c.submit(lambda x: x + 1, 10, workers='mpi-rank-1').result() == 11
 
 
-@pytest.mark.skipif(sys.version_info[0] < 3,
-                    reason="Subprocess issues on Python 2")
 def test_no_scheduler(loop):
     with tmpfile(extension='json') as fn:
-        with popen(['mpirun', '--np', '2', 'dask-mpi', '--scheduler-file', fn], stdin=subprocess.DEVNULL):
+        with popen(['mpirun', '--np', '2', 'dask-mpi', '--scheduler-file', fn], stdin=FNULL):
             with Client(scheduler_file=fn) as c:
 
                 start = time()

--- a/dask_mpi/tests/test_cli.py
+++ b/dask_mpi/tests/test_cli.py
@@ -1,6 +1,11 @@
 from __future__ import print_function, division, absolute_import
+import os
+import sys
 
-import subprocess
+if os.name == 'posix' and sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
 from time import sleep
 
 import pytest
@@ -14,7 +19,8 @@ from distributed.utils import tmpfile
 from distributed.utils_test import popen
 from distributed.utils_test import loop  # noqa: F401
 
-
+@pytest.mark.skipif(sys.version_info[0] < 3,
+                    reason="Subprocess issues on Python 2")
 @pytest.mark.parametrize('nanny', ['--nanny', '--no-nanny'])
 def test_basic(loop, nanny):
     with tmpfile(extension='json') as fn:

--- a/dask_mpi/tests/test_cli.py
+++ b/dask_mpi/tests/test_cli.py
@@ -24,7 +24,7 @@ def test_basic(loop, nanny):
                 n_workers = len(c.scheduler_info()['workers'])
                 while n_workers != 3:
                     n_workers = len(c.scheduler_info()['workers'])
-                    print(f'n_workers = {n_workers}')
+                    print('n_workers = ', n_workers)
                     assert time() < start + 10
                     sleep(0.2)
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from os.path import exists
 from setuptools import setup
 
 
-def environment_dependencies(obj, dependencies: list = None):
+def environment_dependencies(obj, dependencies=None):
     if dependencies is None:
         dependencies = []
     if isinstance(obj, string_types):


### PR DESCRIPTION
This PR closes #7
- [x] Allow CircleCI to run builds for PRs from folks
- [x] Update docker image to continuumio/miniconda:latest
- [x] Add CircleCI, Codecov badges
- [x] Add backport of the subprocess module from Python 3 for use on 2.x
