### PR TITLE
Precursor to adding initialize to __init__.py

### DIFF
--- a/dask_mpi/__init__.py
+++ b/dask_mpi/__init__.py
@@ -1,4 +1,3 @@
-
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions

--- a/dask_mpi/cli.py
+++ b/dask_mpi/cli.py
@@ -5,9 +5,7 @@ from mpi4py import MPI
 from tornado.ioloop import IOLoop
 from distributed.cli.utils import check_python_3
 
-from dask_mpi.common import (get_host_from_interface,
-                             create_scheduler, run_scheduler,
-                             create_and_run_worker)
+from dask_mpi.common import get_host_from_interface, create_scheduler, run_scheduler, create_and_run_worker
 
 comm = MPI.COMM_WORLD
 rank = comm.Get_rank()

--- a/dask_mpi/cli.py
+++ b/dask_mpi/cli.py
@@ -9,7 +9,6 @@ from dask_mpi.common import get_host_from_interface, create_scheduler, run_sched
 
 comm = MPI.COMM_WORLD
 rank = comm.Get_rank()
-loop = IOLoop()
 
 
 @click.command()
@@ -42,6 +41,8 @@ loop = IOLoop()
 def main(scheduler_file, interface, nthreads, local_directory, memory_limit,
          scheduler, bokeh, bokeh_port, bokeh_prefix, nanny, bokeh_worker_port):
     host = get_host_from_interface(interface)
+
+    loop = IOLoop()
 
     if rank == 0 and scheduler:
         scheduler_obj = create_scheduler(loop, host=host, scheduler_file=scheduler_file,

--- a/dask_mpi/common.py
+++ b/dask_mpi/common.py
@@ -33,11 +33,11 @@ def create_scheduler(loop, scheduler_file=None, host=None, bokeh=True, bokeh_por
 
 
 def run_scheduler(scheduler):
-    loop = scheduler.loop
+    scheduler_loop = scheduler.loop
     try:
-        loop.start()
+        scheduler_loop.start()
     finally:
-        loop.close()
+        scheduler_loop.close()
     scheduler.stop()
 
 
@@ -70,13 +70,13 @@ def create_and_run_worker(loop, host=None, rank=0, scheduler_file=None, nanny=Fa
         while worker.status != 'closed':
             yield gen.sleep(0.2)
 
-    loop = worker.loop
+    worker_loop = worker.loop
     try:
-        loop.run_sync(run_until_closed)
+        worker_loop.run_sync(run_until_closed)
     finally:
         @gen.coroutine
         def close():
             yield worker._close(timeout=2)
 
-        loop.run_sync(close)
-        loop.close()
+        worker_loop.run_sync(close)
+        worker_loop.close()

--- a/dask_mpi/core.py
+++ b/dask_mpi/core.py
@@ -63,7 +63,7 @@ def initialize(interface=None, nthreads=1, local_directory='', memory_limit='aut
         run_scheduler(scheduler)
         sys.exit()
     elif rank == 1:
-        return
+        atexit.register(send_close_signal)
     else:
         create_and_run_worker(loop, host=host, rank=rank, nanny=nanny, nthreads=nthreads,
                               local_directory=local_directory, memory_limit=memory_limit,
@@ -81,7 +81,3 @@ def send_close_signal():
 
     with Client() as c:
         c.run_on_scheduler(stop, wait=False)
-
-
-if rank == 1:
-    atexit.register(send_close_signal)

--- a/dask_mpi/core.py
+++ b/dask_mpi/core.py
@@ -12,7 +12,6 @@ from dask_mpi.common import get_host_from_interface, create_scheduler, run_sched
 
 comm = MPI.COMM_WORLD
 rank = comm.Get_rank()
-loop = IOLoop()
 
 
 def initialize(interface=None, nthreads=1, local_directory='', memory_limit='auto', nanny=False,
@@ -47,6 +46,8 @@ def initialize(interface=None, nthreads=1, local_directory='', memory_limit='aut
         Worker's Bokeh port for visual diagnostics
     """
     host = get_host_from_interface(interface)
+
+    loop = IOLoop()
 
     if rank == 0:
         scheduler = create_scheduler(loop, host=host, bokeh=bokeh, bokeh_port=bokeh_port, bokeh_prefix=bokeh_prefix)

--- a/dask_mpi/tests/test_cli.py
+++ b/dask_mpi/tests/test_cli.py
@@ -34,13 +34,12 @@ def test_basic(loop, nanny, mpirun):
                     assert time() < start + 10
                     sleep(0.2)
 
-                assert (
-                    c.submit(lambda x: x + 1, 10, workers="mpi-rank-1").result() == 11
-                )
+                assert c.submit(lambda x: x + 1, 10, workers="mpi-rank-1").result() == 11
 
 
 def test_no_scheduler(loop, mpirun):
     with tmpfile(extension="json") as fn:
+
         cmd = mpirun + ["-np", "2", "dask-mpi", "--scheduler-file", fn]
 
         with popen(cmd, stdin=FNULL):
@@ -53,14 +52,7 @@ def test_no_scheduler(loop, mpirun):
 
                 assert c.submit(lambda x: x + 1, 10).result() == 11
 
-                cmd = mpirun + [
-                    "-np",
-                    "1",
-                    "dask-mpi",
-                    "--scheduler-file",
-                    fn,
-                    "--no-scheduler",
-                ]
+                cmd = mpirun + ["-np", "1", "dask-mpi", "--scheduler-file", fn, "--no-scheduler"]
 
                 with popen(cmd):
                     start = time()
@@ -84,15 +76,7 @@ def check_port_okay(port):
 def test_bokeh_scheduler(loop, mpirun):
     with tmpfile(extension="json") as fn:
 
-        cmd = mpirun + [
-            "-np",
-            "2",
-            "dask-mpi",
-            "--scheduler-file",
-            fn,
-            "--bokeh-port",
-            "59583",
-        ]
+        cmd = mpirun + ["-np", "2", "dask-mpi", "--scheduler-file", fn, "--bokeh-port", "59583"]
 
         with popen(cmd, stdin=FNULL):
             check_port_okay(59583)
@@ -104,14 +88,8 @@ def test_bokeh_scheduler(loop, mpirun):
 @pytest.mark.skip
 def test_bokeh_worker(loop, mpirun):
     with tmpfile(extension="json") as fn:
-        cmd = mpirun + [
-            "-np",
-            "2",
-            "dask-mpi",
-            "--scheduler-file",
-            fn,
-            "--bokeh-worker-port",
-            "59584",
-        ]
+
+        cmd = mpirun + ["-np", "2", "dask-mpi", "--scheduler-file", fn, "--bokeh-worker-port", "59584"]
+
         with popen(cmd, stdin=FNULL):
             check_port_okay(59584)

--- a/dask_mpi/tests/test_core.py
+++ b/dask_mpi/tests/test_core.py
@@ -10,9 +10,7 @@ pytest.importorskip("mpi4py")
 
 
 def test_basic(mpirun):
-    script_file = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)), "core_basic.py"
-    )
+    script_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "core_basic.py")
 
     p = subprocess.Popen(mpirun + ["-np", "4", sys.executable, script_file])
 


### PR DESCRIPTION
These are the precursor steps to adding `initialize` to the `dask_mpi/__init__.py` file.

Everything should work at this point, and these changes (other than some cleanup) simply do the following:

1. move the `IOLoop` declarations into the CLI (`main()`) and core (`initialize`) functions, and
2. move the `atexit.register` call to inside the `initialize` function.

With these changes, I cannot see why adding `initialize` to `dask_mpi/__init__.py` should cause any failures.