### PR TITLE
Support scheduler-port, worker-port and nanny-port args

### DIFF
--- a/dask_mpi/cli.py
+++ b/dask_mpi/cli.py
@@ -14,6 +14,8 @@ rank = comm.Get_rank()
 @click.command()
 @click.option('--scheduler-file', type=str, default='scheduler.json',
               help='Filename to JSON encoded scheduler information.')
+@click.option('--scheduler-port', default=8786, type=int,
+              help="Specify scheduler port number.  Defaults to port 8786.")
 @click.option('--interface', type=str, default=None,
               help="Network interface like 'eth0' or 'ib0'")
 @click.option('--nthreads', type=int, default=0,
@@ -28,8 +30,12 @@ rank = comm.Get_rank()
 @click.option('--scheduler/--no-scheduler', default=True,
               help=("Whether or not to include a scheduler. "
                     "Use --no-scheduler to increase an existing dask cluster"))
+@click.option('--worker-port', type=int, default=0,
+              help="Serving computation port, defaults to random")
 @click.option('--nanny/--no-nanny', default=True,
               help="Start workers in nanny process for management")
+@click.option('--nanny-port', type=int, default=0,
+              help="Serving nanny port, defaults to random")
 @click.option('--bokeh/--no-bokeh', default=True,
               help="Enable Bokeh visual diagnostics")
 @click.option('--bokeh-port', type=int, default=8787,
@@ -39,19 +45,22 @@ rank = comm.Get_rank()
 @click.option('--bokeh-prefix', type=str, default=None,
               help="Prefix for the bokeh app")
 def main(scheduler_file, interface, nthreads, local_directory, memory_limit,
-         scheduler, bokeh, bokeh_port, bokeh_prefix, nanny, bokeh_worker_port):
+         scheduler, bokeh, bokeh_port, bokeh_prefix, bokeh_worker_port,
+         nanny, scheduler_port, nanny_port, worker_port):
     host = get_host_from_interface(interface)
 
     loop = IOLoop()
 
     if rank == 0 and scheduler:
         scheduler_obj = create_scheduler(loop, host=host, scheduler_file=scheduler_file,
-                                         bokeh=bokeh, bokeh_port=bokeh_port, bokeh_prefix=bokeh_prefix)
+                                         bokeh=bokeh, bokeh_port=bokeh_port, bokeh_prefix=bokeh_prefix,
+                                         scheduler_port=scheduler_port)
         run_scheduler(scheduler_obj)
     else:
         create_and_run_worker(loop, host=host, rank=rank, scheduler_file=scheduler_file, nanny=nanny,
                               nthreads=nthreads, local_directory=local_directory, memory_limit=memory_limit,
-                              bokeh=bokeh, bokeh_port=bokeh_worker_port)
+                              bokeh=bokeh, bokeh_port=bokeh_worker_port,
+                              worker_port=worker_port, nanny_port=nanny_port)
 
 
 def go():

--- a/dask_mpi/common.py
+++ b/dask_mpi/common.py
@@ -15,7 +15,8 @@ def get_host_from_interface(interface=None):
     return host
 
 
-def create_scheduler(loop, scheduler_file=None, host=None, bokeh=True, bokeh_port=8787, bokeh_prefix=None):
+def create_scheduler(loop, scheduler_file=None, host=None, bokeh=True, bokeh_port=8787, bokeh_prefix=None,
+                     scheduler_port=None):
     try:
         from distributed.bokeh.scheduler import BokehScheduler
     except ImportError:
@@ -27,7 +28,7 @@ def create_scheduler(loop, scheduler_file=None, host=None, bokeh=True, bokeh_por
         services = {}
 
     scheduler = Scheduler(loop=loop, services=services, scheduler_file=scheduler_file)
-    addr = uri_from_host_port(host, None, 8786)
+    addr = uri_from_host_port(host, scheduler_port, 8786)
     scheduler.start(addr)
     return scheduler
 
@@ -43,7 +44,8 @@ def run_scheduler(scheduler):
 
 def create_and_run_worker(loop, host=None, rank=0, scheduler_file=None, nanny=False,
                           local_directory='', nthreads=0, memory_limit='auto',
-                          bokeh=True, bokeh_port=8789, bokeh_prefix=None):
+                          bokeh=True, bokeh_port=8789, bokeh_prefix=None,
+                          worker_port=None, nanny_port=None):
     try:
         from distributed.bokeh.worker import BokehWorker
     except ImportError:
@@ -54,6 +56,15 @@ def create_and_run_worker(loop, host=None, rank=0, scheduler_file=None, nanny=Fa
     else:
         services = {}
 
+    if nanny:
+        port = nanny_port
+        kwargs = {'worker_port': worker_port}
+        W = Nanny
+    else:
+        port = worker_port
+        kwargs = {}
+        W = Worker
+
     W = Nanny if nanny else Worker
     worker = W(scheduler_file=scheduler_file,
                loop=loop,
@@ -61,8 +72,10 @@ def create_and_run_worker(loop, host=None, rank=0, scheduler_file=None, nanny=Fa
                ncores=nthreads,
                local_dir=local_directory,
                services=services,
-               memory_limit=memory_limit)
-    addr = uri_from_host_port(host, None, 0)
+               memory_limit=memory_limit,
+               **kwargs)
+
+    addr = uri_from_host_port(host, port, 0)
 
     @gen.coroutine
     def run_until_closed():

--- a/dask_mpi/tests/test_cli.py
+++ b/dask_mpi/tests/test_cli.py
@@ -87,7 +87,7 @@ def test_non_default_ports(loop, nanny, mpirun):
                     worker_host, worker_port = get_address_host_port(
                         worker_addr)
                     assert worker_port == 58464
-                    if nanny:
+                    if nanny == "--nanny":
                         nanny_port = worker_info['services']['nanny']
                         assert nanny_port == 50164
 

--- a/dask_mpi/tests/test_cli.py
+++ b/dask_mpi/tests/test_cli.py
@@ -74,7 +74,7 @@ def test_non_default_ports(loop, nanny, mpirun):
             with Client(scheduler_file=fn) as c:
 
                 start = time()
-                while len(c.scheduler_info()["workers"]) != 3:
+                while len(c.scheduler_info()["workers"]) != 1:
                     assert time() < start + 10
                     sleep(0.2)
 


### PR DESCRIPTION
@kmpaul 

Does this seem like the right approach?

**Note:** I was only able to test with `no-nanny`, as the Nannies don't seem to be forking Workers in my tests. I believe our installation of MPI allows this. But perhaps this is for another issue.