### PR TITLE
Add logic to broadcast current scheduler info to workers in CLI

### DIFF
--- a/dask_mpi/cli.py
+++ b/dask_mpi/cli.py
@@ -3,10 +3,11 @@ import click
 import asyncio
 
 import dask
-from dask.distributed import Client, Scheduler, Worker, Nanny
+from dask.distributed import Scheduler, Worker, Nanny
 from distributed.cli.utils import check_python_3
 
 from mpi4py import MPI
+
 
 @click.command()
 @click.option(
@@ -88,7 +89,7 @@ def main(
                 await s.finished()
 
         asyncio.get_event_loop().run_until_complete(run_scheduler())
- 
+
     else:
         scheduler_address = comm.bcast(None, root=0)
         dask.config.set(scheduler_address=scheduler_address)
@@ -108,6 +109,7 @@ def main(
                 await worker.finished()
 
         asyncio.get_event_loop().run_until_complete(run_worker())
+
 
 def go():
     check_python_3()

--- a/dask_mpi/cli.py
+++ b/dask_mpi/cli.py
@@ -84,15 +84,13 @@ def main(
                 dashboard_address=dashboard_address,
                 scheduler_file=scheduler_file,
             ) as s:
-                comm.bcast(s.address, root=0)
                 comm.Barrier()
                 await s.finished()
 
         asyncio.get_event_loop().run_until_complete(run_scheduler())
 
+
     else:
-        scheduler_address = comm.bcast(None, root=0)
-        dask.config.set(scheduler_address=scheduler_address)
         comm.Barrier()
 
         async def run_worker():

--- a/dask_mpi/cli.py
+++ b/dask_mpi/cli.py
@@ -1,15 +1,13 @@
 import click
 
 import asyncio
-from mpi4py import MPI
+import sys
 
 import dask
 from dask.distributed import Client, Scheduler, Worker, Nanny
 from distributed.cli.utils import check_python_3
 
-comm = MPI.COMM_WORLD
-rank = comm.Get_rank()
-
+from mpi4py import MPI
 
 @click.command()
 @click.option(
@@ -73,6 +71,9 @@ def main(
     scheduler_port,
     protocol,
 ):
+
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
 
     if rank == 0 and scheduler:
 

--- a/dask_mpi/cli.py
+++ b/dask_mpi/cli.py
@@ -74,7 +74,7 @@ def main(
     protocol,
 ):
 
-    if rank == 0:
+    if rank == 0 and scheduler:
 
         async def run_scheduler():
             async with Scheduler(

--- a/dask_mpi/cli.py
+++ b/dask_mpi/cli.py
@@ -2,7 +2,6 @@ import click
 
 import asyncio
 
-import dask
 from dask.distributed import Scheduler, Worker, Nanny
 from distributed.cli.utils import check_python_3
 
@@ -88,7 +87,6 @@ def main(
                 await s.finished()
 
         asyncio.get_event_loop().run_until_complete(run_scheduler())
-
 
     else:
         comm.Barrier()

--- a/dask_mpi/cli.py
+++ b/dask_mpi/cli.py
@@ -1,7 +1,6 @@
 import click
 
 import asyncio
-import sys
 
 import dask
 from dask.distributed import Client, Scheduler, Worker, Nanny
@@ -82,14 +81,14 @@ def main(
                 interface=interface,
                 protocol=protocol,
                 dashboard_address=dashboard_address,
-            ) as scheduler:
-                comm.bcast(scheduler.address, root=0)
+                scheduler_file=scheduler_file,
+            ) as s:
+                comm.bcast(s.address, root=0)
                 comm.Barrier()
-                await scheduler.finished()
+                await s.finished()
 
         asyncio.get_event_loop().run_until_complete(run_scheduler())
-        sys.exit()
-
+ 
     else:
         scheduler_address = comm.bcast(None, root=0)
         dask.config.set(scheduler_address=scheduler_address)
@@ -104,11 +103,11 @@ def main(
                 memory_limit=memory_limit,
                 local_directory=local_directory,
                 name=rank,
+                scheduler_file=scheduler_file,
             ) as worker:
                 await worker.finished()
 
         asyncio.get_event_loop().run_until_complete(run_worker())
-        sys.exit()
 
 def go():
     check_python_3()

--- a/dask_mpi/tests/test_cli.py
+++ b/dask_mpi/tests/test_cli.py
@@ -25,7 +25,7 @@ FNULL = open(os.devnull, "w")  # hide output of subprocess
 def test_basic(loop, nanny, mpirun):
     with tmpfile(extension="json") as fn:
 
-        cmd = mpirun + ["-np", "4", "dask-mpi", "--scheduler-file", fn, nanny]
+        cmd = mpirun + ["-np", "4", "dask-mpi", "--scheduler-file", fn, nanny, "&"]
 
         with popen(cmd):
             with Client(scheduler_file=fn) as c:
@@ -40,7 +40,7 @@ def test_basic(loop, nanny, mpirun):
 def test_no_scheduler(loop, mpirun):
     with tmpfile(extension="json") as fn:
 
-        cmd = mpirun + ["-np", "2", "dask-mpi", "--scheduler-file", fn]
+        cmd = mpirun + ["-np", "2", "dask-mpi", "--scheduler-file", fn, "&"]
 
         with popen(cmd, stdin=FNULL):
             with Client(scheduler_file=fn) as c:
@@ -59,6 +59,7 @@ def test_no_scheduler(loop, mpirun):
                     "--scheduler-file",
                     fn,
                     "--no-scheduler",
+                    "&",
                 ]
 
                 with popen(cmd):
@@ -86,6 +87,7 @@ def test_non_default_ports(loop, nanny, mpirun):
             "58464",
             "--nanny-port",
             "50164",
+            "&",
         ]
 
         with popen(cmd):
@@ -132,6 +134,7 @@ def test_dashboard(loop, mpirun):
             fn,
             "--dashboard-address",
             ":59583",
+            "&",
         ]
 
         with popen(cmd, stdin=FNULL):
@@ -153,6 +156,7 @@ def test_bokeh_worker(loop, mpirun):
             fn,
             "--bokeh-worker-port",
             "59584",
+            "&",
         ]
 
         with popen(cmd, stdin=FNULL):

--- a/dask_mpi/tests/test_cli.py
+++ b/dask_mpi/tests/test_cli.py
@@ -25,7 +25,7 @@ FNULL = open(os.devnull, "w")  # hide output of subprocess
 def test_basic(loop, nanny, mpirun):
     with tmpfile(extension="json") as fn:
 
-        cmd = mpirun + ["-np", "4", "dask-mpi", "--scheduler-file", fn, nanny, "&"]
+        cmd = mpirun + ["-np", "4", "dask-mpi", "--scheduler-file", fn, nanny]
 
         with popen(cmd):
             with Client(scheduler_file=fn) as c:
@@ -40,7 +40,7 @@ def test_basic(loop, nanny, mpirun):
 def test_no_scheduler(loop, mpirun):
     with tmpfile(extension="json") as fn:
 
-        cmd = mpirun + ["-np", "2", "dask-mpi", "--scheduler-file", fn, "&"]
+        cmd = mpirun + ["-np", "2", "dask-mpi", "--scheduler-file", fn]
 
         with popen(cmd, stdin=FNULL):
             with Client(scheduler_file=fn) as c:
@@ -59,7 +59,6 @@ def test_no_scheduler(loop, mpirun):
                     "--scheduler-file",
                     fn,
                     "--no-scheduler",
-                    "&",
                 ]
 
                 with popen(cmd):
@@ -87,7 +86,6 @@ def test_non_default_ports(loop, nanny, mpirun):
             "58464",
             "--nanny-port",
             "50164",
-            "&",
         ]
 
         with popen(cmd):
@@ -134,7 +132,6 @@ def test_dashboard(loop, mpirun):
             fn,
             "--dashboard-address",
             ":59583",
-            "&",
         ]
 
         with popen(cmd, stdin=FNULL):
@@ -156,7 +153,6 @@ def test_bokeh_worker(loop, mpirun):
             fn,
             "--bokeh-worker-port",
             "59584",
-            "&",
         ]
 
         with popen(cmd, stdin=FNULL):


### PR DESCRIPTION
This PR addresses the problem described in @rcthomas issue #45 

I think there was some confusion in this issue-- at NERSC our idea at the moment is to recommend that our users start Dask via the dask-mpi CLI (which never touches core.py, as far as we can tell.)

This PR implements the same logic in cli.py that already exists in core.py. It first starts the scheduler and then broadcasts the scheduler address to the workers before they can start. This behavior prevents the workers from reading an old scheduler.json file (which may have been left behind after a non-clean exit) and then hanging while they try to connect to a scheduler which does not exist. 
