### PR TITLE
Bump GHA setup-miniconda version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
           path: ~/conda_pkgs_dir
           key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles( env.ENV_FILE ) }}
       - name: Setup miniconda
-        uses: goanpeca/setup-miniconda@v1
+        uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: dask-mpi-dev # Defined in ci/env-mpi.yml
           auto-update-conda: false


### PR DESCRIPTION
setup-miniconda v2 fixes some deprecations in GitHub Actions. The project has also been moved to conda-incubator.