### PR TITLE
Update local_directory WorkerType argument. Removes deprecation warning.

### DIFF
--- a/dask_mpi/core.py
+++ b/dask_mpi/core.py
@@ -85,7 +85,7 @@ def initialize(
                 protocol=protocol,
                 nthreads=nthreads,
                 memory_limit=memory_limit,
-                local_dir=local_directory,
+                local_directory=local_directory,
                 name=rank,
             ) as worker:
                 await worker.finished()


### PR DESCRIPTION
The WorkerType keyword argument has been changed from local_dir to local_directory. This removes a depreciation warning when launching workers. 