### PR TITLE
Added connecting to dashboard to docs

### DIFF
--- a/dask_mpi/core.py
+++ b/dask_mpi/core.py
@@ -38,14 +38,12 @@ def initialize(
         integer (nbytes), float (fraction of total memory), or 'auto'.
     nanny : bool
         Start workers in nanny process for management
-    bokeh : bool
+    dashboard : bool
         Enable Bokeh visual diagnostics
-    bokeh_port : int
+    dashboard_address : str
         Bokeh port for visual diagnostics
-    bokeh_prefix : str
-        Prefix for the bokeh app
-    bokeh_worker_port : int
-        Worker's Bokeh port for visual diagnostics
+    protocol : str
+        Protocol like 'inproc' or 'tcp'
     """
     from mpi4py import MPI
 
@@ -59,6 +57,7 @@ def initialize(
             async with Scheduler(
                 interface=interface,
                 protocol=protocol,
+                dashboard=dashboard,
                 dashboard_address=dashboard_address,
             ) as scheduler:
                 comm.bcast(scheduler.address, root=0)

--- a/docs/source/batch.rst
+++ b/docs/source/batch.rst
@@ -53,3 +53,34 @@ Nannies) will be terminated.
    resources used by the ``mpirun`` command.
 
 For more details on the ``initialize()`` method, see the :ref:`api`.
+
+Connecting to Dashboard
+-----------------------
+
+Due to the fact that Dask might be initialized on a node that isn't the login node
+a simple port forwarding can be insufficient to connect to a dashboard.
+
+To find out which node is the one hosting the dashboard append initialization code with location logging:
+
+.. code-block:: python
+
+   from dask_mpi import initialize
+   initialize()
+
+   from dask.distributed import Client
+   from distributed.scheduler import logger
+   import socket
+
+   client = Client()
+
+   host = client.run_on_scheduler(socket.gethostname)
+   port = client.scheduler_info()['services']['dashboard']
+   login_node_address = "supercomputer.university.edu" # Provide address/domain of login node
+
+   logger.info(f"ssh -N -L {port}:{host}:{port} {login_node_address}")
+
+Then in batch job output file search for the logged line and use in your terminal::
+
+   ssh -N -L PORT_NUMBER:node03:PORT_NUMBER supercomputer.university.edu
+
+The Bokeh Dashboard will be available at ``localhost:PORT_NUMBER``.

--- a/docs/source/develop.rst
+++ b/docs/source/develop.rst
@@ -29,3 +29,13 @@ Test using ``pytest``::
 
    py.test dask_mpi --verbose
 
+Build docs
+----------
+
+To build docs site after cloning and installing from sources use::
+
+    cd dask-mpi/docs
+    make html
+
+Output will be placed in ``build`` directory.
+Required dependencies for building docs can be found in ``dask-mpi/docs/environment.yml``.


### PR DESCRIPTION
Hi @andersy005!

Here's a small docs PR about connecting to the dashboard as described in https://github.com/dask/dask/discussions/7480. (Also added `build docs` in `develop.rst`) Screenshots: 

![img](https://i.imgur.com/YT2NlcB.png)
![img](https://i.imgur.com/csJMJlj.png)

I also updated docstring to suit method's parameters in `core.py` - if it's unnecessary I will revert it.