### PR TITLE
Experimental update to use new Distributed Runner base class

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = click,dask,distributed,mpi4py,pytest,requests,setuptools,tornado,yaml
+known_third_party = click,dask,distributed,pytest,requests,setuptools,yaml

--- a/dask_mpi/__init__.py
+++ b/dask_mpi/__init__.py
@@ -1,5 +1,5 @@
 from ._version import get_versions
-from .core import initialize
+from .core import initialize, MPIRunner
 
 __version__ = get_versions()["version"]
 del get_versions

--- a/dask_mpi/__init__.py
+++ b/dask_mpi/__init__.py
@@ -1,5 +1,5 @@
 from ._version import get_versions
-from .core import initialize, MPIRunner
+from .core import MPIRunner, initialize
 
 __version__ = get_versions()["version"]
 del get_versions

--- a/dask_mpi/core.py
+++ b/dask_mpi/core.py
@@ -2,7 +2,7 @@ import atexit
 
 import dask
 from dask.distributed import Scheduler
-from distributed.deploy.runner import Runner, Role
+from distributed.deploy.runner import Role, Runner
 
 _RUNNER_REF = None
 

--- a/dask_mpi/tests/core_context.py
+++ b/dask_mpi/tests/core_context.py
@@ -1,0 +1,17 @@
+from time import sleep
+
+from distributed import Client
+from distributed.metrics import time
+
+from dask_mpi import MPIRunner
+
+with MPIRunner() as runner:
+    with Client(runner) as c:
+
+        start = time()
+        while len(c.scheduler_info()["workers"]) != 2:
+            assert time() < start + 10
+            sleep(0.2)
+
+        assert c.submit(lambda x: x + 1, 10).result() == 11
+        assert c.submit(lambda x: x + 1, 20, workers=2).result() == 21

--- a/dask_mpi/tests/test_cli.py
+++ b/dask_mpi/tests/test_cli.py
@@ -11,7 +11,7 @@ import requests
 from distributed import Client
 from distributed.comm.addressing import get_address_host_port
 from distributed.metrics import time
-from distributed.utils import import_term, tmpfile
+from distributed.utils import tmpfile
 from distributed.utils_test import loop  # noqa: F401
 from distributed.utils_test import popen
 
@@ -20,8 +20,11 @@ pytest.importorskip("mpi4py")
 FNULL = open(os.devnull, "w")  # hide output of subprocess
 
 
-@pytest.mark.parametrize("nanny", ["--no-nanny", "--nanny"])
-def test_basic(loop, nanny, mpirun):
+@pytest.mark.parametrize(
+    "worker_class",
+    ["distributed.Worker", "distributed.Nanny", "dask_cuda.CUDAWorker"],
+)
+def test_basic(loop, worker_class, mpirun):
     with tmpfile(extension="json") as fn:
 
         cmd = mpirun + [

--- a/dask_mpi/tests/test_cli.py
+++ b/dask_mpi/tests/test_cli.py
@@ -20,7 +20,7 @@ pytest.importorskip("mpi4py")
 FNULL = open(os.devnull, "w")  # hide output of subprocess
 
 
-@pytest.mark.parametrize("nanny", ["--nanny", "--no-nanny"])
+@pytest.mark.parametrize("nanny", ["--no-nanny", "--nanny"])
 def test_basic(loop, nanny, mpirun):
     with tmpfile(extension="json") as fn:
 

--- a/dask_mpi/tests/test_core.py
+++ b/dask_mpi/tests/test_core.py
@@ -17,4 +17,17 @@ def test_basic(mpirun):
     p = subprocess.Popen(mpirun + ["-np", "4", sys.executable, script_file])
 
     p.communicate()
+    print("mpirun ended")
+    assert p.returncode == 0
+
+
+def test_context(mpirun):
+    script_file = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), "core_context.py"
+    )
+
+    p = subprocess.Popen(mpirun + ["-np", "4", sys.executable, script_file])
+
+    p.communicate()
+    print("mpirun ended")
     assert p.returncode == 0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-asyncio
+pytest-timeout

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ parentdir_prefix = dask_mpi-
 
 [tool:pytest]
 addopts = -rsx -v --durations=10
+timeout = 15
 minversion = 3.2
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')


### PR DESCRIPTION
This project is awesome and really neatly solves the issue of bootstrapping a Dask cluster on an MPI system.

There are other batch systems which do not use MPI that could make use of this method.

I've raised dask/distributed#4710 which adds a new `Runner` base class to `distributed` which simplifies the implementation of this kind of cluster bootstrapping.

This PR is an example of how it could be used to re-implement dask-mpi.

It introduces an `MPIRunner` class which is used in place of the `initialize` function to create the cluster. It can be used as a context manager and more closely follows the `Cluster` pattern seen in other Dask deployment projects.

Instead of invoking `initialize` which does everything under the hood, including silently updating the scheduler address in the Dask config, we can use a context manager to do things explicitly.

```python
from distributed import Client
from dask_mpi import MPIRunner

with MPIRunner() as runner:  # Only rank 1 executes the code within the context manager, everything else blocks here running the scheduler and workers
    with Client(runner) as c:

        # Do client things
```

I've also updated the CLI and `initialize` to use `MPIRunner` under the hook to reduce code duplication and keep backward compatibility.

```python
from distributed import Client
from dask_mpi import initialize

initialize()  # Creates an MPIRunner and sets the Dask config

with Client(runner) as c:

    # Do client things
```

My hope here is to be able to use the concepts that I've upstreamed into `Runner` in other projects like `dask-cloudprovider`.
