### PR TITLE
Add support for alternative worker classes and additional worker options

### DIFF
--- a/dask_mpi/cli.py
+++ b/dask_mpi/cli.py
@@ -1,10 +1,10 @@
 import asyncio
+import json
 
 import click
-import json
-from dask.distributed import Nanny, Scheduler, Worker
-from distributed.utils import import_term
+from dask.distributed import Scheduler, Worker
 from distributed.cli.utils import check_python_3
+from distributed.utils import import_term
 from mpi4py import MPI
 
 
@@ -117,16 +117,17 @@ def main(
                     "Option --no-nanny is deprectaed, use --worker-class instead"
                 )
                 WorkerType = Worker
-            async with WorkerType(
-                interface=interface,
-                protocol=protocol,
-                nthreads=nthreads,
-                memory_limit=memory_limit,
-                local_directory=local_directory,
-                name=rank,
-                scheduler_file=scheduler_file,
-                **worker_options
-            ) as worker:
+            opts = {
+                "interface": interface,
+                "protocol": protocol,
+                "nthreads": nthreads,
+                "memory_limit": memory_limit,
+                "local_directory": local_directory,
+                "name": rank,
+                "scheduler_file": scheduler_file,
+                **worker_options,
+            }
+            async with WorkerType(**opts) as worker:
                 await worker.finished()
 
         asyncio.get_event_loop().run_until_complete(run_worker())

--- a/dask_mpi/core.py
+++ b/dask_mpi/core.py
@@ -3,7 +3,7 @@ import atexit
 import sys
 
 import dask
-from dask.distributed import Client, Nanny, Scheduler, Worker
+from dask.distributed import Client, Nanny, Scheduler
 from distributed.utils import import_term
 from tornado import gen
 from tornado.ioloop import IOLoop
@@ -93,15 +93,16 @@ def initialize(
                     "Option nanny=True is deprectaed, use worker_class='distributed.Nanny' instead"
                 )
                 WorkerType = Nanny
-            async with WorkerType(
-                interface=interface,
-                protocol=protocol,
-                nthreads=nthreads,
-                memory_limit=memory_limit,
-                local_directory=local_directory,
-                name=rank,
-                **worker_options
-            ) as worker:
+            opts = {
+                "interface": interface,
+                "protocol": protocol,
+                "nthreads": nthreads,
+                "memory_limit": memory_limit,
+                "local_directory": local_directory,
+                "name": rank,
+                **worker_options,
+            }
+            async with WorkerType(**opts) as worker:
                 await worker.finished()
 
         asyncio.get_event_loop().run_until_complete(run_worker())

--- a/dask_mpi/tests/test_cli.py
+++ b/dask_mpi/tests/test_cli.py
@@ -11,7 +11,7 @@ import requests
 from distributed import Client
 from distributed.comm.addressing import get_address_host_port
 from distributed.metrics import time
-from distributed.utils import tmpfile, import_term
+from distributed.utils import import_term, tmpfile
 from distributed.utils_test import loop  # noqa: F401
 from distributed.utils_test import popen
 

--- a/docs/source/gpu.rst
+++ b/docs/source/gpu.rst
@@ -1,0 +1,62 @@
+Dask-MPI with GPUs
+==================
+
+When running `dask-mpi` on GPU enabled systems you will be provided with one or more GPUs per MPI rank.
+
+Today Dask assumes one worker process per GPU with workers tied correctly to each GPU. To help with this
+the `dask-cuda <https://docs.rapids.ai/api/dask-cuda/nightly/index.html>`_ package exists which contains
+cluster and worker classes which are designed to correctly configure your GPU environment.
+
+.. code-block:: bash
+
+    conda install -c rapidsai -c nvidia -c conda-forge dask-cuda
+    # or
+    python -m pip install dask-cuda
+
+It is possible to leverage ``dask-cuda`` with ``dask-mpi`` by setting the worker class to use ``dask_cuda.CUDAWorker``.
+
+.. code-block:: bash
+
+    mpirun -np 4 dask-mpi --worker-class dask_cuda.CUDAWorker
+
+.. code-block:: python
+
+    from dask_mpi import initialize
+
+    initialize(worker_class="dask_cuda.CUDAWorker")
+
+
+.. tip::
+
+   If your cluster is configured so that each rank represents one node you may have multiple GPUs
+   per node. Workers will be created per GPU, not per rank so ``CUDAWorker`` will create one worker
+   per GPU with names following the pattern   ``{rank}-{gpu_index}``. So if you set ``-np 4`` but you
+   have four GPUs per node you will end up with   sixteen workers in your cluster.
+
+Additional configuration
+------------------------
+
+You may also want to pass additional configuration options to ``dask_cuda.CUDAWorker`` in addition to the ones
+supported by ``dask-mpi``. It is common to configure things like memory management and network protocols for
+GPU workers.
+
+You can pass any additional options that are accepted by ``dask_cuda.CUDAWorker`` with the worker options paramater.
+
+On the CLI this is expected to be a JSON serialised dictionary of values.
+
+.. code-block:: bash
+
+    mpirun -np 4 dask-mpi --worker-class dask_cuda.CUDAWorker --worker-options '{"rmm_managed_memory": true}'
+
+In Python it is just a dictionary.
+
+.. code-block:: python
+
+    from dask_mpi import initialize
+
+    initialize(worker_class="dask_cuda.CUDAWorker", worker_options={"rmm_managed_memory": True})
+
+.. tip::
+
+    For more information on using GPUs with Dask check out the `dask-cuda documentation
+    <https://docs.rapids.ai/api/dask-cuda/nightly/index.html>`_.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -75,6 +75,7 @@ during your computation, or for interactive use.
    install
    batch
    interactive
+   gpu
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/interactive.rst
+++ b/docs/source/interactive.rst
@@ -53,14 +53,14 @@ Scheduler (whose address is in the scheduler JSON file).
 .. warning:: **MPI Jobs and Dask Nannies**
 
    It is many times useful to launch your Dask-MPI cluster (using ``dask-mpi``) with Dask Nannies
-   (i.e., with the ``--nanny`` option), rather than strictly with Dask Workers.  This is because
-   the Dask Nannies can relaunch a worker when a failure occurs.  However, in some MPI environments,
-   Dask Nannies will not be able to work as expected.  This is because some installations of MPI
-   may restrict the number of actual running processes from exceeding the number of MPI ranks
+   (i.e., with the ``--worker-class distributed.Nanny`` option), rather than strictly with Dask Workers.
+   This is because the Dask Nannies can relaunch a worker when a failure occurs. However, in some MPI
+   environments, Dask Nannies will not be able to work as expected.  This is because some installations
+   of MPI may restrict the number of actual running processes from exceeding the number of MPI ranks
    requested.  When using Dask Nannies, the Nanny process is executed and runs in the background
    after forking a Worker process.  Hence, one Worker process will exist for each Nanny process.
    Some MPI installations will kill any forked process, and you will see many errors arising from
    the Worker processes being killed.  If this happens, disable the use of Nannies with the
-   ``--no-nanny`` option to ``dask-mpi``.
+   ``--worker-class distributed.Worker`` option to ``dask-mpi``.
 
 For more details on how to use the ``dask-mpi`` command, see the :ref:`cli`.


### PR DESCRIPTION
Today `dask-mpi` has a boolean `--nanny` flag and `nanny` kwarg for CLI and interactive respecively for choosing between `Worker` and `Nanny` as the worker class.

This PR deprecates that (but doesn't remove it) and adds `--worker-class` and `worker_class` which can be used to set the class to a custom value. This came up when trying to use `dask-mpi` on GPU nodes where the class needed to be set to `dask_cuda.CUDAWorker`.

```console
$ mpirun -np 4 dask-mpi --worker-class dask_cuda.CUDAWorker
```

```python
from dask_mpi import initialize
initialize(worker_class="dask_cuda.CUDAWorker")
```

I've also added a new `--worker-options` flag which takes a JSON serialised dict and `worker_options` which takes a dict of extra kwargs to be passed to the worker class. This is important for `CUDAWorker` for configuring things like memory management, but will also be useful for anyone wanting to further configure `Worker` and `Nanny`.

```console
$ mpirun -np 4 dask-mpi --worker-class dask_cuda.CUDAWorker --worker-options '{"rmm_managed_memory": true}'
```

```python
from dask_mpi import initialize
initialize(worker_class="dask_cuda.CUDAWorker", worker_options={"rmm_managed_memory": True})
```