### PR TITLE
Add support for use as part of a wider MPI process

### DIFF
--- a/dask_mpi/__init__.py
+++ b/dask_mpi/__init__.py
@@ -1,5 +1,5 @@
 from ._version import get_versions
-from .core import initialize
+from .core import initialize, send_close_signal
 
 __version__ = get_versions()["version"]
 del get_versions

--- a/dask_mpi/core.py
+++ b/dask_mpi/core.py
@@ -73,6 +73,7 @@ def initialize(
     """
     if comm is None:
         from mpi4py import MPI
+
         comm = MPI.COMM_WORLD
 
     rank = comm.Get_rank()
@@ -148,6 +149,7 @@ def send_close_signal():
     You only need to call this manually when using exit=False
     in initialize.
     """
+
     async def stop(dask_scheduler):
         await dask_scheduler.close()
         await gen.sleep(0.1)

--- a/dask_mpi/tests/core_no_exit.py
+++ b/dask_mpi/tests/core_no_exit.py
@@ -1,10 +1,5 @@
-from time import sleep
-
 from distributed import Client
-from distributed.metrics import time
-
 from dask_mpi import initialize, send_close_signal
-
 from mpi4py.MPI import COMM_WORLD as world
 
 # Split our MPI world into two pieces, one consisting just of
@@ -21,8 +16,6 @@ if world.rank != 3:
             c.submit(lambda x: x + 1, 10).result() == 11
             c.submit(lambda x: x + 1, 20).result() == 21
         send_close_signal()
-
-
 
 # check that our original comm is intact
 world.Barrier()

--- a/dask_mpi/tests/core_no_exit.py
+++ b/dask_mpi/tests/core_no_exit.py
@@ -1,0 +1,31 @@
+from time import sleep
+
+from distributed import Client
+from distributed.metrics import time
+
+from dask_mpi import initialize, send_close_signal
+
+from mpi4py.MPI import COMM_WORLD as world
+
+# Split our MPI world into two pieces, one consisting just of
+# the old rank 3 process and the other with everything else
+new_comm_assignment = 1 if world.rank == 3 else 0
+comm = world.Split(new_comm_assignment)
+
+if world.rank != 3:
+    # run tests with rest of comm
+    is_client = initialize(comm=comm, exit=False)
+
+    if is_client:
+        with Client() as c:
+            c.submit(lambda x: x + 1, 10).result() == 11
+            c.submit(lambda x: x + 1, 20).result() == 21
+        send_close_signal()
+
+
+
+# check that our original comm is intact
+world.Barrier()
+x = 100 if world.rank == 0 else 200
+x = world.bcast(x)
+assert x == 100

--- a/dask_mpi/tests/core_no_exit.py
+++ b/dask_mpi/tests/core_no_exit.py
@@ -1,6 +1,7 @@
 from distributed import Client
-from dask_mpi import initialize, send_close_signal
 from mpi4py.MPI import COMM_WORLD as world
+
+from dask_mpi import initialize, send_close_signal
 
 # Split our MPI world into two pieces, one consisting just of
 # the old rank 3 process and the other with everything else

--- a/dask_mpi/tests/test_no_exit.py
+++ b/dask_mpi/tests/test_no_exit.py
@@ -1,0 +1,20 @@
+from __future__ import absolute_import, division, print_function
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+pytest.importorskip("mpi4py")
+
+
+def test_no_exit(mpirun):
+    script_file = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), "core_no_exit.py"
+    )
+
+    p = subprocess.Popen(mpirun + ["-np", "4", sys.executable, script_file])
+
+    p.communicate()
+    assert p.returncode == 0


### PR DESCRIPTION
The current version of the code always uses MPI_COMM_WORLD as the communicator and calls sys.exit on some processes when the client process exits python.

This change makes it possible to use dask-mpi for part of an MPI process but then return to the original MPI workflow once it is complete. It requires the user to manually call `send_close_signal` from the client process, and to use a returned value indicating whether the process is the client or not.