### PR TITLE
Use new Dask docs theme

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,6 +1,6 @@
 name: dask-mpi-docs
 channels:
-  - conda-forge 
+  - conda-forge
   - nodefaults
 dependencies:
   - dask>=2.19
@@ -12,6 +12,6 @@ dependencies:
   - pygments
   - pip
   - pip:
-    - dask_sphinx_theme
-    - numpydoc
-    - sphinx-click
+      - dask_sphinx_theme>=2
+      - numpydoc
+      - sphinx-click


### PR DESCRIPTION
Bumping the minimum docs theme to use the new version. This isn't strictly necessary but I wanted to raise a PR to trigger the rtd preview and check everything looks ok.

xref dask/dask-sphinx-theme#54