### PR TITLE
Rename atexit handler to not break backwards compatability

### DIFF
--- a/dask_mpi/__init__.py
+++ b/dask_mpi/__init__.py
@@ -1,5 +1,5 @@
 from ._version import get_versions
-from .core import finalize, initialize
+from .core import initialize, send_close_signal
 
 __version__ = get_versions()["version"]
 del get_versions

--- a/dask_mpi/core.py
+++ b/dask_mpi/core.py
@@ -105,7 +105,7 @@ def initialize(
 
     if rank == 1:
         if exit:
-            atexit.register(finalize)
+            atexit.register(send_close_signal)
         return True
     else:
 
@@ -135,7 +135,7 @@ def initialize(
             return False
 
 
-def finalize():
+def send_close_signal():
     """
     The client can call this function to explicitly stop
     the event loop.

--- a/dask_mpi/tests/core_no_exit.py
+++ b/dask_mpi/tests/core_no_exit.py
@@ -1,7 +1,7 @@
 from distributed import Client
 from mpi4py.MPI import COMM_WORLD as world
 
-from dask_mpi import finalize, initialize
+from dask_mpi import initialize, send_close_signal
 
 # Split our MPI world into two pieces, one consisting just of
 # the old rank 3 process and the other with everything else
@@ -16,7 +16,7 @@ if world.rank != 3:
         with Client() as c:
             c.submit(lambda x: x + 1, 10).result() == 11
             c.submit(lambda x: x + 1, 20).result() == 21
-        finalize()
+        send_close_signal()
 
 # check that our original comm is intact
 world.Barrier()


### PR DESCRIPTION
I renamed the `send_close_signal` function which breaks backwards compatibility.  This changes it back.