### PR TITLE
Disabling Python 3.9+ in tests (for now)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.6', '3.7', '3.8']
+        python: ['3.7', '3.8']
         mpi: ['mpich', 'openmpi']
     env:
       PYTHON: ${{ matrix.python }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.8', '3.9', '3.10']
+        python: ['3.6', '3.7', '3.8']
         mpi: ['mpich', 'openmpi']
     env:
       PYTHON: ${{ matrix.python }}


### PR DESCRIPTION
This is a temporary hack to allow tests to pass until #87 can be addressed properly.