### PR TITLE
stable MPI.COMM_WORLD for scaling out to hundreds of node

### DIFF
--- a/dask_mpi/core.py
+++ b/dask_mpi/core.py
@@ -8,6 +8,7 @@ from distributed.utils import import_term
 
 
 def initialize(
+    comm,
     interface=None,
     nthreads=1,
     local_directory="",
@@ -18,7 +19,6 @@ def initialize(
     protocol=None,
     worker_class="distributed.Worker",
     worker_options=None,
-    comm=None,
     exit=True,
 ):
     """
@@ -36,6 +36,8 @@ def initialize(
 
     Parameters
     ----------
+    comm: mpi4py.MPI.Intracomm
+        Optional MPI communicator to use instead of COMM_WORLD
     interface : str
         Network interface like 'eth0' or 'ib0'
     nthreads : int
@@ -57,8 +59,6 @@ def initialize(
         Class to use when creating workers
     worker_options : dict
         Options to pass to workers
-    comm: mpi4py.MPI.Intracomm
-        Optional MPI communicator to use instead of COMM_WORLD
     exit: bool
         Whether to call sys.exit on the workers and schedulers when the event
         loop completes.
@@ -69,11 +69,8 @@ def initialize(
         Only returned if exit=False. Inidcates whether this rank should continue
         to run client code (True), or if it acts as a scheduler or worker (False).
     """
-    if comm is None:
-        from mpi4py import MPI
-
-        comm = MPI.COMM_WORLD
-
+    assert comm is not None, "MPI Comm World needs to be created before import distributed."
+    
     rank = comm.Get_rank()
 
     if not worker_options:


### PR DESCRIPTION
Previously, `initialize()` allows creating MPI comm world after `import distributed` 
```
from distributed import Client, Nanny, Scheduler
from distributed.utils import import_term
...

def initialize(
...):
if comm is None:
        from mpi4py import MPI

        comm = MPI.COMM_WORLD

```

However, as I tested on large-scale clusters with hundreds of nodes, as the number of workers increases, typically when it gets more than 32, `initialize()` function will be stuck at:
```
# scheduler
comm.bcast(scheduler.address, root=0)
comm.Barrier()
```
and 
```
# worker
scheduler_address = comm.bcast(None, root=0)
dask.config.set(scheduler_address=scheduler_address)
comm.Barrier()
```
Because some worker processes fail to receive the bcast'd scheduler address. 
After a long time of debugging, I found that this is strongly related to the order of `import mpi4py` and `import distributed` (or `from distributed import`). I am guessing that in `distributed`, some communication environment settings are made first which then leads to some conflicts when `mpi4py` tries to bootstrap the MPI.COMM_WORLD after it. 

By strictly requiring the user to create the MPI.COMM_WORLD before calling the `initialize()` function, the above problem no longer bothers. According to my test, it can scale out to more than 128 workers (maybe more, as my resource is limited) without any hanging issues.