### PR TITLE
Raise an exception if the comm world is too small

### DIFF
--- a/dask_mpi/__init__.py
+++ b/dask_mpi/__init__.py
@@ -1,5 +1,6 @@
 from ._version import get_versions
 from .core import initialize, send_close_signal
+from .exceptions import WorldTooSmallException
 
 __version__ = get_versions()["version"]
 del get_versions

--- a/dask_mpi/cli.py
+++ b/dask_mpi/cli.py
@@ -102,7 +102,7 @@ def main(
     if scheduler and world_size < 2:
         raise WorldTooSmallException(
             f"Not enough MPI ranks to start cluster, found {world_size}, "
-            "needs at least 2 for the scheduler and at least 1 worker."
+            "needs at least 2, one for the scheduler and a worker."
         )
 
     rank = comm.Get_rank()

--- a/dask_mpi/cli.py
+++ b/dask_mpi/cli.py
@@ -6,6 +6,8 @@ from distributed import Scheduler, Worker
 from distributed.utils import import_term
 from mpi4py import MPI
 
+from .exceptions import WorldTooSmallException
+
 
 @click.command()
 @click.argument("scheduler_address", type=str, required=False)
@@ -95,6 +97,14 @@ def main(
     name,
 ):
     comm = MPI.COMM_WORLD
+
+    world_size = comm.Get_size()
+    if scheduler and world_size < 2:
+        raise WorldTooSmallException(
+            f"Not enough MPI ranks to start cluster, found {world_size}, "
+            "needs at least 2 for the scheduler and at least 1 worker."
+        )
+
     rank = comm.Get_rank()
 
     try:

--- a/dask_mpi/cli.py
+++ b/dask_mpi/cli.py
@@ -102,7 +102,7 @@ def main(
     if scheduler and world_size < 2:
         raise WorldTooSmallException(
             f"Not enough MPI ranks to start cluster, found {world_size}, "
-            "needs at least 2, one for the scheduler and a worker."
+            "needs at least 2, one each for the scheduler and a worker."
         )
 
     rank = comm.Get_rank()

--- a/dask_mpi/core.py
+++ b/dask_mpi/core.py
@@ -80,7 +80,7 @@ def initialize(
     if world_size < 3:
         raise WorldTooSmallException(
             f"Not enough MPI ranks to start cluster, found {world_size}, "
-            "needs 3 or more, one for the scheduler, client and a worker."
+            "needs at least 3, one each for the scheduler, client and a worker."
         )
 
     rank = comm.Get_rank()

--- a/dask_mpi/core.py
+++ b/dask_mpi/core.py
@@ -80,7 +80,7 @@ def initialize(
     if world_size < 3:
         raise WorldTooSmallException(
             f"Not enough MPI ranks to start cluster, found {world_size}, "
-            "needs 3 or more for the scheduler, client and at least 1 worker."
+            "needs 3 or more, one for the scheduler, client and a worker."
         )
 
     rank = comm.Get_rank()

--- a/dask_mpi/core.py
+++ b/dask_mpi/core.py
@@ -6,6 +6,8 @@ import dask
 from distributed import Client, Nanny, Scheduler
 from distributed.utils import import_term
 
+from .exceptions import WorldTooSmallException
+
 
 def initialize(
     interface=None,
@@ -73,6 +75,13 @@ def initialize(
         from mpi4py import MPI
 
         comm = MPI.COMM_WORLD
+
+    world_size = comm.Get_size()
+    if world_size < 3:
+        raise WorldTooSmallException(
+            f"Not enough MPI ranks to start cluster, found {world_size}, "
+            "needs 3 or more for the scheduler, client and at least 1 worker."
+        )
 
     rank = comm.Get_rank()
 

--- a/dask_mpi/exceptions.py
+++ b/dask_mpi/exceptions.py
@@ -1,0 +1,2 @@
+class WorldTooSmallException(RuntimeError):
+    """Not enough MPI ranks to start all required processes."""

--- a/dask_mpi/tests/test_cli.py
+++ b/dask_mpi/tests/test_cli.py
@@ -51,6 +51,24 @@ def test_basic(loop, worker_class, mpirun):
                 assert c.submit(lambda x: x + 1, 10).result() == 11
 
 
+def test_small_world(mpirun):
+    with tmpfile(extension="json") as fn:
+        # Set too few processes to start cluster
+        p = subprocess.Popen(
+            mpirun
+            + [
+                "-np",
+                "1",
+                "dask-mpi",
+                "--scheduler-file",
+                fn,
+            ]
+        )
+
+        p.communicate()
+        assert p.returncode != 0
+
+
 def test_no_scheduler(loop, mpirun):
     with tmpfile(extension="json") as fn:
         cmd = mpirun + ["-np", "2", "dask-mpi", "--scheduler-file", fn]

--- a/dask_mpi/tests/test_core.py
+++ b/dask_mpi/tests/test_core.py
@@ -18,3 +18,15 @@ def test_basic(mpirun):
 
     p.communicate()
     assert p.returncode == 0
+
+
+def test_small_world(mpirun):
+    script_file = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), "core_basic.py"
+    )
+
+    # Set too few processes to start cluster
+    p = subprocess.Popen(mpirun + ["-np", "1", sys.executable, script_file])
+
+    p.communicate()
+    assert p.returncode != 0


### PR DESCRIPTION
When using the CLI to start a cluster with a scheduler it assumes there will be at least two ranks, one for the scheduler and one for one or more workers. When using the `initialize` function it assumes at least three ranks, one for the scheduler, one for the client and one or more workers.

This PR adds a runtime check for this and if there aren't enough processes in the MPI Comm World it raises an exception to avoid hanging and waiting for processes that will never arrive.

```console
$ mpirun -np 1 dask-mpi        
...
--------------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jtomlinson/miniconda3/envs/dask/bin/dask-mpi", line 33, in <module>
    sys.exit(load_entry_point('dask-mpi', 'console_scripts', 'dask-mpi')())
  File "/home/jtomlinson/miniconda3/envs/dask/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/jtomlinson/miniconda3/envs/dask/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/jtomlinson/miniconda3/envs/dask/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/jtomlinson/miniconda3/envs/dask/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/jtomlinson/Projects/dask/dask-mpi/dask_mpi/cli.py", line 103, in main
    raise WorldTooSmallException(
dask_mpi.exceptions.WorldTooSmallException: Not enough MPI ranks to start cluster, found 1, needs at least 2, one each for the scheduler and a worker.
--------------------------------------------------------------------------
Primary job  terminated normally, but 1 process returned
a non-zero exit code. Per user-direction, the job has been aborted.
--------------------------------------------------------------------------
--------------------------------------------------------------------------
mpirun detected that one or more processes exited with non-zero status, thus causing
the job to be terminated. The first process to do so was:

  Process name: [[20199,1],0]
  Exit code:    1
--------------------------------------------------------------------------
```