### PR TITLE
List dependencies correctly in distributions.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ import versioneer
 def environment_dependencies(obj, dependencies=None):
     if dependencies is None:
         dependencies = []
-    # if isinstance(obj, string_types):
-    #     dependencies.append(obj.replace('=', '=='))
+    if isinstance(obj, str):
+        dependencies.append(obj)
     elif isinstance(obj, dict):
         if "dependencies" in obj:
             environment_dependencies(obj["dependencies"], dependencies=dependencies)


### PR DESCRIPTION
I noticed that when installing `dask-mpi` by itself, it does not come
with any dependencies, contrary to what `setup.py` hints at.

On a barebones cluster, I got this trying to set up a small reproducer:
```
-bash-4.2$ python3 -mvenv foobar; . ./foobar/bin/activate; pip install dask-mpi
Collecting dask-mpi
  Using cached dask_mpi-2022.4.0-py3-none-any.whl (11 kB)
Installing collected packages: dask-mpi
Successfully installed dask-mpi-2022.4.0
(foobar) -bash-4.2$ pip list
Package    Version
---------- --------
dask-mpi   2022.4.0
pip        22.0.4
setuptools 47.1.0
```

It seems that the code that actually specifies the dependencies has been
commented out for a while. This PR reactivates it.

Tested with `python -mbuild -n` (no build isolation due to the YAML
dependency for `setup.py`) and looking at the `METADATA` file of the
resulting wheel.
