### PR TITLE
Fix: Make local_directory None by default

### DIFF
--- a/dask_mpi/core.py
+++ b/dask_mpi/core.py
@@ -12,7 +12,7 @@ from .exceptions import WorldTooSmallException
 def initialize(
     interface=None,
     nthreads=1,
-    local_directory="",
+    local_directory=None,
     memory_limit="auto",
     nanny=False,
     dashboard=True,
@@ -42,7 +42,7 @@ def initialize(
         Network interface like 'eth0' or 'ib0'
     nthreads : int
         Number of threads per worker
-    local_directory : str
+    local_directory : str or None
         Directory to place worker files
     memory_limit : int, float, or 'auto'
         Number of bytes before spilling data to disk.  This can be an


### PR DESCRIPTION
This is to ensure that if workers are launched with dask_mpi, the local_directory can be modified via dask.config('temporary_directory').
In https://github.com/dask/distributed/blob/main/distributed/core.py#L385 it assumes None default value, not "". 