### PR TITLE
Add --dashboard/--no-dashboard flag and enable by default

### DIFF
--- a/dask_mpi/cli.py
+++ b/dask_mpi/cli.py
@@ -69,6 +69,13 @@ from .exceptions import WorldTooSmallException
     help="JSON serialised dict of options to pass to workers",
 )
 @click.option(
+    "--dashboard/--no-dashboard",
+    "dashboard",
+    default=True,
+    required=False,
+    help="Launch the Dashboard [default: --dashboard]",
+)
+@click.option(
     "--dashboard-address",
     type=str,
     default=None,
@@ -88,6 +95,7 @@ def main(
     local_directory,
     memory_limit,
     scheduler,
+    dashboard,
     dashboard_address,
     nanny,
     worker_class,
@@ -118,6 +126,7 @@ def main(
             async with Scheduler(
                 interface=interface,
                 protocol=protocol,
+                dashboard=dashboard,
                 dashboard_address=dashboard_address,
                 scheduler_file=scheduler_file,
                 port=scheduler_port,

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - mpich
   - mpi4py>=3.0.3
   - versioneer
-  - sphinx
+  - sphinx>=5.0
   - pygments
   - pip
   - pip:


### PR DESCRIPTION
Closes #126 

Currently when running `dask-mpi` the dashboard is disabled unless you set the `--dashboard-address` flag to some value.

```bash
# Old behaviour

# Dashboard disabled (the default)
mpirun -np $SLURM_NTASKS dask-mpi --scheduler-file scheduler.json

# Dashboard enabled
mpirun -np $SLURM_NTASKS dask-mpi --scheduler-file scheduler.json --dashboard-address :8787
```

In the `dask scheduler` CLI there is a flag to enable/disable the dashboard and it defaults to enabled. This PR adds the same `--dashboard/--no-dashboard` flag to the `dask-mpi` CLI and also sets the default as enabled.

```bash
# New behaviour

# Dashboard enabled (the default)
mpirun -np $SLURM_NTASKS dask-mpi --scheduler-file scheduler.json

# Dashboard disabled
mpirun -np $SLURM_NTASKS dask-mpi --scheduler-file scheduler.json --no-dashboard
```