### PR TITLE
Fix CI failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,10 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v2
 
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v1
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.10
 
       - name: Install pypa/build
         run: python -m pip install build wheel pyyaml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: Install pypa/build
         run: python -m pip install build wheel pyyaml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cache conda
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           # Increase this value to reset cache if ci/environment.yml has not changed
           CACHE_NUMBER: 0

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,5 +1,8 @@
 version: 2
 
+sphinx:
+  configuration: docs/source/conf.py
+
 build:
   os: "ubuntu-22.04"
   tools:


### PR DESCRIPTION
CI is currently failing for a couple of reasons, this PR fixes things up:
- The cache action version we are currently using (v2) is deprecated and is causing CI to fail in #132.
- [Readthedocs now requires the sphinx config path to be set explicitly](https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/)
- Bump `actions/setup-python` to `v5` as it couldn't find Python 3.8. Also bumped release Python version to 3.10.

https://github.com/dask/dask-mpi/actions/runs/13637854290/job/38120837200?pr=132